### PR TITLE
Fix publication time for qualitative benchmarks post

### DIFF
--- a/_posts/2026-09-04-the-code-they-leave-behind.md
+++ b/_posts/2026-09-04-the-code-they-leave-behind.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "The Code They Leave Behind"
-date: 2026-09-04 12:00:00
+date: 2026-09-04 07:40:08 -0400
 tags: technical
 author: "Stephen Benjamin"
 ---


### PR DESCRIPTION
Sets the post date to its actual merge/publication time (07:40:08 EDT). The previous noon timestamp caused Jekyll to treat the post as future-dated and omit it from the site index.